### PR TITLE
Fix PV3 Support, Allow 1, 2 or 3 strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ __pycache__/
 # C extensions
 *.so
 
+# IntelliJ
+.idea/
+*.iml
+
+# MacOs
+.DS_Store
+
 # Distribution / packaging
 .Python
 build/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sensor:
     - platform: kostal_plenticore
       host: <IP>
       password: <Password>
-      DC_Inputs: 2 #Optional Default 2 (2,3)
+      dc_inputs: 2 # Optional, default: 2, valid values: 1, 2, 3
       monitored_conditions:
         - BatteryPercent
         - BatteryCycles
@@ -92,3 +92,6 @@ sensor:
         - LimitEvuAbs
 
 ```
+Note: 
+* PV2* sensors will be ignored if dc_inputs < 2
+* PV3* sensors will be ignored if dc_inputs < 3

--- a/custom_components/kostal_plenticore/const.py
+++ b/custom_components/kostal_plenticore/const.py
@@ -12,6 +12,9 @@ from homeassistant.const import (
     POWER_WATT,
 )
 
+CONF_DCINPUTS = "dc_inputs"
+CONF_DCINPUTS_DEFAULT = 2
+
 SENSOR_TYPES = {
     "BatteryPercent": [
         "devices:local:battery",
@@ -87,27 +90,6 @@ SENSOR_TYPES = {
         "devices:local:pv1",
         "I",
         "Kostal PV1 Current",
-        ELECTRICAL_CURRENT_AMPERE,
-        "mdi:solar-power",
-    ],
-    "PV2Power": [
-        "devices:local:pv2",
-        "P",
-        "Kostal PV2 Power",
-        POWER_WATT,
-        "mdi:solar-power",
-    ],
-    "PV2Voltage": [
-        "devices:local:pv2",
-        "U",
-        "Kostal PV2 Voltage",
-        VOLT,
-        "mdi:solar-power",
-    ],
-    "PV2Current": [
-        "devices:local:pv2",
-        "I",
-        "Kostal PV2 Current",
         ELECTRICAL_CURRENT_AMPERE,
         "mdi:solar-power",
     ],
@@ -475,6 +457,30 @@ SENSORS_DC3 = {
         "devices:local:pv3",
         "I",
         "Kostal PV3 Current",
+        ELECTRICAL_CURRENT_AMPERE,
+        "mdi:solar-power",
+    ]
+}
+
+SENSORS_DC2 = {
+    "PV2Power": [
+        "devices:local:pv2",
+        "P",
+        "Kostal PV2 Power",
+        POWER_WATT,
+        "mdi:solar-power",
+    ],
+    "PV2Voltage": [
+        "devices:local:pv2",
+        "U",
+        "Kostal PV2 Voltage",
+        VOLT,
+        "mdi:solar-power",
+    ],
+    "PV2Current": [
+        "devices:local:pv2",
+        "I",
+        "Kostal PV2 Current",
         ELECTRICAL_CURRENT_AMPERE,
         "mdi:solar-power",
     ]


### PR DESCRIPTION
In reply to https://github.com/ITTV-tools/homeassistant-kostalplenticore/issues/15

I checked the code and found that it could be simplified.
This pull requests enables your extension to run with either 1, 2 or 3 dc_inputs (strings), whereas 2 is the default.

The PV2* sensors will be ignored if dc_inputs < 2
The PV3* sensors will be ignored if dc_inputs < 3

The "pvcombined" will also work correctly. 
Please check if this expect's your needs.

I checked it by setting the number of strings to 1, 2 and 3
